### PR TITLE
feat(python-stack): Implementation of RGB image fetching from Earth Engine

### DIFF
--- a/computation/imagefetcher/.gitignore
+++ b/computation/imagefetcher/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 *.egg-info/
+*.pyc

--- a/computation/imagefetcher/imagefetcher/__init__.py
+++ b/computation/imagefetcher/imagefetcher/__init__.py
@@ -1,1 +1,7 @@
-# Sample init file, to bootstrap the package.
+#!/usr/bin/env python2
+
+"""Image fetcher service.
+
+Fetch satellite images from the Google Earth Engine API. Exposed as a REST
+service.
+"""

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -3,8 +3,8 @@
 """Application definition for the Image Fetcher API.
 
 The Image Fetcher creates a Flask server handling several routes sending
-requests to the Google Earth Engine, that generates a link to download
-images. All routes returns matadatas containing notably the download link.
+requests to the Google Earth Engine that generates a link to download
+images. All routes returns metadata containing notably the download link.
 
 This application requires a Google Earth Engine token to work. If you do not
 own one, please ask one on the official website [1]. If you do own one, you
@@ -107,8 +107,8 @@ def GetRGBImage():
         polygon = json.loads(raw_polygon)
         assert type(polygon) == list, "Not a list"
         assert all(type(p) == list for p in polygon), "Not a list of list."
-        assert all(len(p) == 2 for p in polygon), ("Some points have "
-            "does not have 2 coords.")
+        assert all(len(p) == 2 for p in polygon), ("Some points do not have 2 "
+                "coords.")
         assert all(all(type(c) in (int, float) for c in p)
                 for p in polygon), "Some points have invalid types."
         assert polygon[0] == polygon[-1], "Last point must equal first point."

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python2
+
+"""Application definition for the Image Fetcher API.
+
+The Image Fetcher creates a Flask server handling several routes sending
+requests to the Google Earth Engine, that generates a link to download
+images. All routes returns matadatas containing notably the download link.
+
+This application requires a Google Earth Engine token to work. If you do not
+own one, please ask one on the official website [1]. If you do own one, you
+can initialize it by running the following command:
+    python2 -c "import ee; ee.Initialize()"
+
+Defined routes are:
+    /rgb
+"""
+
+import ee
+import gflags
+import json
+
+from datetime import datetime
+from datetime import timedelta
+from flask import Flask
+from flask import jsonify
+from flask import request
+
+from fetcher import ImageFetcher
+
+
+app = Flask(__name__)
+
+FLAGS = gflags.FLAGS
+gflags.DEFINE_string("default_delta", "0000-03-00", "default range "
+        "within images are still considered as 'close to the date'.")
+gflags.DEFINE_string("default_scale", "100", "default image scale, "
+        "in meter per pixels (lower is better).")
+gflags.DEFINE_string("host", "0.0.0.0", "Server listening host.")
+gflags.DEFINE_integer("port", 5000, "Server listening port.")
+gflags.DEFINE_boolean("debug", False, "Run in debug mode.")
+
+# Initialize the Google Earth Engine
+ee.Initialize()
+
+
+fetcher = ImageFetcher()
+
+
+class Error(Exception):
+    """Exception raised when an error occurs in the API."""
+
+    status_code = 400
+
+    def __init__(self, message, status_code=400):
+        Exception.__init__(self)
+        self.message = message
+        self.status_code = status_code
+
+    def to_dict(self):
+        return {"error": self.message}
+
+
+@app.errorhandler(Error)
+def handle_error(error):
+    """Handler triggered when the Error exception is raised."""
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
+@app.route('/rgb')
+def GetRGBImage():
+    """Generates a RGB image of an area. Images are in PNG (in a zip).
+
+    GET query parameters:
+        date (yyyy-mm-dd):
+            Average date of the image to fetch. Required.
+        polygon (list[list[int]]):
+            Area to visualize. Required.
+        scale (int):
+            Precision of the picture. Unit is meter per pixels so lower is
+            better.
+        delta (yyyy-mm-dd):
+            Delta within images are considered valid.
+    Returns:
+        A JSON containing metadata about the image:
+            href (link):
+                Link to download the image.
+            error (str):
+                In case of error, displays the error message.
+    """
+    raw_date = request.args.get('date')
+    if raw_date is None:
+        raise Error("Missing required argument 'date'.")
+    raw_polygon = request.args.get('polygon')
+    if raw_polygon is None:
+        raise Error("Missing required argument 'polygon'.")
+    raw_delta = request.args.get('delta', FLAGS.default_delta)
+    raw_scale = request.args.get('scale', FLAGS.default_scale)
+
+    try:
+        date = datetime.strptime(raw_date, "%Y-%m-%d")
+    except ValueError as e:
+        raise Error(str(e))
+
+    try:
+        polygon = json.loads(raw_polygon)
+        assert type(polygon) == list, "Not a list"
+        assert all(type(p) == list for p in polygon), "Not a list of list."
+        assert all(len(p) == 2 for p in polygon), ("Some points have "
+            "does not have 2 coords.")
+        assert all(all(type(c) in (int, float) for c in p)
+                for p in polygon), "Some points have invalid types."
+        assert polygon[0] == polygon[-1], "Last point must equal first point."
+    except ValueError:
+        raise Error("Unreadable JSON sent in 'polygon' argument.")
+    except AssertionError as e:
+        raise Error("Invalid JSON. Error was: " + str(e))
+
+    try:
+        year, month, day = [int(t) for t in raw_delta.split("-")]
+        start_date = datetime(date.year - year, date.month - month, date.day - day)
+        end_date = datetime(date.year + year, date.month + month, date.day + day)
+    except ValueError:
+        raise Error("Malformed delta date.")
+
+    try:
+        scale = int(raw_scale)
+    except ValueError:
+        raise Error("Scale is not an integer.")
+
+    url = fetcher.GetRGBImage(start_date, end_date, polygon, scale)
+    return jsonify(href=url)
+
+
+@app.route("/")
+def main_route():
+    """Simple route useful for checking if the server is alive."""
+    return ""
+
+
+if __name__ == "__main__":
+    import sys
+    FLAGS(sys.argv)
+    app.run(host=FLAGS.host, port=FLAGS.port, debug=FLAGS.debug)

--- a/computation/imagefetcher/imagefetcher/app_test.py
+++ b/computation/imagefetcher/imagefetcher/app_test.py
@@ -8,6 +8,8 @@ import unittest
 
 import app
 
+FLAGS = gflags.FLAGS
+
 VALID_DATE = "2015-04-01"
 VALID_POLYGON = json.dumps([[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]])
 
@@ -21,14 +23,14 @@ def shutdown():
 class RGBRouteTest(unittest.TestCase):
     """Test the /rgb route is correctly handled."""
 
-    server_address = ("127.0.0.1", 5000)
-    base_url = "http://%s:%s/rgb" % (server_address)
-
     @classmethod
     def setUpClass(cls):
-        """Setup the Flask server and start listening for requests."""
-        # We need to load the flags library before running the tests.
+        """Set up the Flask server and start listening for requests."""
+        # Generate server address, based on port flag's default value.
         gflags.FLAGS([])
+        cls.server_address = ("127.0.0.1", FLAGS.port)
+        cls.base_url = "http://%s:%s/rgb" % (cls.server_address)
+
         cls.thread = threading.Thread(target=app.app.run,
                 args=cls.server_address)
         cls.thread.start()

--- a/computation/imagefetcher/imagefetcher/app_test.py
+++ b/computation/imagefetcher/imagefetcher/app_test.py
@@ -1,0 +1,117 @@
+import flask
+import gflags
+import json
+import mock
+import requests
+import threading
+import unittest
+
+import app
+
+VALID_DATE = "2015-04-01"
+VALID_POLYGON = json.dumps([[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]])
+
+@app.app.route('/shutdown')
+def shutdown():
+    """Shutdown the flask application."""
+    flask.request.environ.get('werkzeug.server.shutdown')()
+    return ""
+
+
+class RGBRouteTest(unittest.TestCase):
+    """Test the /rgb route is correctly handled."""
+
+    server_address = ("127.0.0.1", 5000)
+    base_url = "http://%s:%s/rgb" % (server_address)
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Flask server and start listening for requests."""
+        # We need to load the flags library before running the tests.
+        gflags.FLAGS([])
+        cls.thread = threading.Thread(target=app.app.run,
+                args=cls.server_address)
+        cls.thread.start()
+
+        # Save the fetcher previously generated in the app module. We are going
+        # to override it. Everytime.
+        cls._base_fetcher = app.fetcher
+
+    @classmethod
+    def tearDownClass(cls):
+        """Shutdown the Flask server."""
+        requests.get("http://%s:%s/shutdown" % cls.server_address)
+        cls.thread.join()
+
+        # Reset the fetcher.
+        app.fetcher = cls._base_fetcher
+
+    def setUp(self):
+        """Test setup. Defines a new mock in the fetcher."""
+        self.fetcher = mock.MagicMock()
+        app.fetcher = self.fetcher
+
+    def test_server_running(self):
+        """Simply test the server is running."""
+        response = requests.get("http://%s:%s/" % self.server_address)
+        self.assertEquals(response.status_code, 200)
+
+    def test_missing_arguments(self):
+        """Test if missing arguments are correctly handled."""
+        response = requests.get(self.base_url)
+        self.assertEquals(response.status_code, 400)
+        response = requests.get(self.base_url, params={'date': '2000-01-01'})
+        self.assertEquals(response.status_code, 400)
+        response = requests.get(self.base_url,
+            params={'polygon': VALID_POLYGON})
+        self.assertEquals(response.status_code, 400)
+
+    def test_invalid_date(self):
+        """Test if invalid date is correctly handled."""
+        response = requests.get(self.base_url, params={
+            'date': 'bad-bad',
+            'polygon': VALID_POLYGON,
+        })
+        self.assertEquals(response.status_code, 400)
+
+    def test_invalid_polygon(self):
+        """Test if invalid polygons are correctly handled."""
+        invalids = [
+            {"somekey": "somevalue"},
+            [1, 2],
+            [[1, 2, 3], [1, 2], [1, 3]],
+            [["1", "2"], ["2", "3"]],
+        ]
+
+        for invalid in invalids:
+            response = requests.get(self.base_url, params={
+                'date': VALID_DATE,
+                'polygon': json.dumps(invalid)
+            })
+            self.assertEqual(response.status_code, 400)
+
+    def test_valid_simple_query(self):
+        """Test a valid query."""
+        self.fetcher.GetRGBImage.return_value = "http://something.com/foo"
+        response = requests.get(self.base_url, params={
+            'date': VALID_DATE,
+            'polygon': VALID_POLYGON,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.fetcher.GetRGBImage.called)
+
+    def test_valid_complex_query(self):
+        """Test a valid query with all parameters."""
+        self.fetcher.GetRGBImage.return_value = "http://something.com/foo"
+        response = requests.get(self.base_url, params={
+            'date': VALID_DATE,
+            'polygon': VALID_POLYGON,
+            'scale': 1000,
+            'delta': '0000-01-00',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.fetcher.GetRGBImage.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computation/imagefetcher/imagefetcher/fetcher.py
+++ b/computation/imagefetcher/imagefetcher/fetcher.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python2
+
+"""Image fetcher, reaching the Google Earth Engine to get images from it."""
+
+import ee
+import time
+import threading
+
+from collections import deque
+
+# We cannot use a flag here, because of how the application is designed.
+DEFAULT_QUERY_PER_SECONDS = 3
+
+class RateLimit:
+    """Implementation of a rate limiter.
+
+    This class is highly inspired from the Riot Watcher project, with some
+    cool functionalities added.
+    """
+
+    def __init__(self, allowed_requests, seconds):
+        """Constructor.
+
+        Parameters:
+            allowed_requests: number of allowed requests during the time frame.
+            seconds: time frame, in seconds.
+        """
+        self.allowed_requests = allowed_requests
+        self.seconds = seconds
+        self.made_requests = deque()
+        self.lock = threading.Lock()
+
+    def _reload(self):
+        """Remove old requests."""
+        t = time.time()
+        while len(self.made_requests) > 0 and self.made_requests[0] < t:
+            self.made_requests.popleft()
+
+    def add_request(self):
+        """Add a request to the counter."""
+        self.made_requests.append(time.time() + self.seconds)
+
+    def requests_available(self):
+        """Check if a request is available.
+
+        Returns:
+            False if the rate limit is reached.
+        """
+        self._reload()
+        return len(self.made_requests) < self.allowed_requests
+
+    def __enter__(self):
+        """Context management: blocking requests in a threaded context."""
+        self.lock.acquire()
+        while not self.requests_available():
+            time.sleep(0.1)
+
+    def __exit__(self, *args):
+        """Context management: release the lock in threaded context."""
+        self.lock.release()
+
+
+class ImageFetcher:
+    """Implementation of the image fetcher."""
+
+    def __init__(self, query_per_seconds=DEFAULT_QUERY_PER_SECONDS):
+        """Constructor. Initialize a rate limit.
+
+        Parameters:
+            query_per_seconds: number of query per seconds on the backend.
+        """
+        self.rate_limiter = RateLimit(query_per_seconds, 1)
+
+    def _GetRGBImage(self, start_date, end_date, polygon, scale):
+        """Generates a RGB satellite image of an area within two dates.
+
+        See :meth:`GetRGBImage` for information about the parameters.
+        """
+        geometry = ee.Geometry.Polygon([polygon])
+
+        print(start_date, end_date, polygon, scale)
+
+        # Get the Landsat 8 collection.
+        # TODO(funkysayu) might be good taking a look at other ones.
+        raw_collection = (ee.ImageCollection('LANDSAT/LC8_L1T')
+                .filterDate(start_date, end_date)
+                .filterBounds(geometry))
+
+        # Reduce the collection to one image, and clip it to the bounds.
+        image = raw_collection.median().clip(geometry)
+
+        # Create a visualization of the image
+        visualization = image.visualize(
+            min=6000,
+            max=18000,
+            bands=['B4', 'B3', 'B2'],
+        )
+
+        # Finally generate the png
+        return visualization.getDownloadUrl({
+            'region': geometry.toGeoJSONString(),
+            'scale': scale,
+            'format': 'png',
+        })
+
+    def GetRGBImage(self, start_date, end_date, polygon, scale=100):
+        """Generates a RGB satellite image of an area within two dates.
+
+        Parameters:
+            start_date: images in the collection generating the final picture
+                must have a later date than this one.
+            end_date: images in the collection generating the final picture
+                must have a earlier date than this one.
+            polygon: area to fetch; a list of latitude and longitude making a
+                polygon.
+            scale: image resolution, in meters per pixels.
+        Returns:
+            An URL to the generated image.
+        """
+        with self.rate_limiter:
+            return self._GetRGBImage(start_date, end_date, polygon, scale)

--- a/computation/imagefetcher/imagefetcher/fetcher.py
+++ b/computation/imagefetcher/imagefetcher/fetcher.py
@@ -64,7 +64,7 @@ class ImageFetcher:
     """Implementation of the image fetcher."""
 
     def __init__(self, query_per_seconds=DEFAULT_QUERY_PER_SECONDS):
-        """Constructor. Initialize a rate limit.
+        """Constructor. Initializes a rate limit.
 
         Parameters:
             query_per_seconds: number of query per seconds on the backend.

--- a/computation/imagefetcher/requirements.txt
+++ b/computation/imagefetcher/requirements.txt
@@ -1,3 +1,6 @@
 google-api-python-client
 pyCrypto
 earthengine-api
+mock
+flask
+python-gflags


### PR DESCRIPTION
Using Flask, we expose a REST API with a single route (/rgb) allowing to
fetch images from the Google Earth Engine at a specific date in a specific location.

By default (but this can be parametrized) the service will get all satellite images
taken 3 months before and after the date, and merge them (using the
median of overlapping pixels) to avoid images with too much noise (such
as clouds for example). The scale (in meter per pixel) can also be
parametrized, with a default value of 100.