### PR TITLE
feat(python-stack): Add route generating vegetation difference in an area

### DIFF
--- a/computation/imagefetcher/README.md
+++ b/computation/imagefetcher/README.md
@@ -25,3 +25,16 @@ ee.Initialize()
 image = ee.Image('srtm90_v4')
 print(image.getInfo())
 ```
+
+**Important note**: whenever an update is done on the code, you may need to
+re-run the installation.
+
+## Usage
+
+Once you installed the module, you can run it with the following command:
+
+    python2 -m imagefetcher [options...]
+
+You can also run tests if needed:
+
+    python2 -m imagefetcher.tests

--- a/computation/imagefetcher/examples/ndvi_difference.py
+++ b/computation/imagefetcher/examples/ndvi_difference.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python2
+
+"""Example of server-side computations used in global forest change analysis.
+
+In this example we will focus on server side computation using NDVI and EVI
+data. This both metrics are computed bands created by third party companies
+or directly taken by the satellites.
+
+NDVI and EVI are two metrics used in global forest change analysis. They
+represent the forest concentration in a specific area. We will use the
+MOD13A1 vegetation indice provided by the NASA [1].
+
+The goal is to generate an RGB image, where reds stands for deforestation,
+gree for reforestation and blue for masked data (e.g. rivers, oceans...).
+
+  [1] https://code.earthengine.google.com/dataset/MODIS/MOD13A1
+"""
+
+import ee
+
+# Initialize the Earth Engine
+ee.Initialize()
+
+# Small rectangle used to generate the image, over the Amazonian forest.
+# The location is above the Rondonia (West of Bresil).
+rectangle = ee.Geometry.Rectangle(-68, -7, -65, -8)
+
+# Get the MODIS dataset.
+collection = ee.ImageCollection('MODIS/MOD13A1')
+
+# Select the EVI, since it is more accurate on this dataset. You can also
+# use the NDVI band here.
+collection = collection.select(['EVI'])
+
+# Get two dataset, one over the year 2000 and the other one over 2015
+ndvi2000 = collection.filterDate('2000-01-01', '2000-12-31').median()
+ndvi2015 = collection.filterDate('2015-01-01', '2015-12-31').median()
+
+# Substract the two datasets to see the evolution between both of them.
+difference = ndvi2015.subtract(ndvi2000)
+
+# Use a mask to avoid showing data on rivers.
+# TODO(funkysayu) move this mask to blue color.
+classifiedImage = ee.Image('MODIS/051/MCD12Q1/2001_01_01')
+mask = classifiedImage.select(['Land_Cover_Type_1'])
+maskedDifference = difference.updateMask(mask)
+
+# Convert it to RGB image.
+visualized = maskedDifference.visualize(
+    min=-2000,
+    max=2000,
+    palette='FF0000, 000000, 00FF00',
+)
+
+# Finally generate the PNG.
+print visualized.getDownloadUrl({
+    'region': rectangle.toGeoJSONString(),
+    'scale': 500,
+    'format': 'png',
+})

--- a/computation/imagefetcher/imagefetcher/__main__.py
+++ b/computation/imagefetcher/imagefetcher/__main__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python2
+
+
+"""Image fetcher module entry point.
+
+This file contains is the entry point to the following command:
+    python2 -m imagefetcher
+
+This will startup the Flask application.
+"""
+
+import sys
+import gflags
+
+from imagefetcher.app import app
+
+FLAGS = gflags.FLAGS
+
+if __name__ == "__main__":
+    FLAGS(sys.argv)
+    app.run(host=FLAGS.host, port=FLAGS.port, debug=FLAGS.debug)

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -107,7 +107,7 @@ def forest_diff_handler(polygon, start, stop, scale):
         polygon (list[list[int]]):
             Area to visualize. Required.
         start (int):
-            Reference year. Must be greater or equal than 2000.
+            Reference year. Must be greater than or equal to 2000.
         stop (int):
             Year on which we will subtract the data generated from start year.
             Must be greater than start year, and lower than current year.

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -59,7 +59,7 @@ def handle_error(error):
 @app.route('/rgb')
 @get_param("date", parser=Parser.date, required=True)
 @get_param("polygon", parser=Parser.polygon, required=True)
-@get_param("scale", parser=int, default=100)
+@get_param("scale", parser=float, default=100)
 @get_param("delta", parser=Parser.date_delta, default=DateDelta(0, 3, 0))
 def rgb_handler(date, polygon, scale, delta):
     """Generates a RGB image of an area. Images are in PNG (in a zip).
@@ -69,7 +69,7 @@ def rgb_handler(date, polygon, scale, delta):
             Average date of the image to fetch. Required.
         polygon (list[list[int]]):
             Area to visualize. Required.
-        scale (int):
+        scale (float):
             Precision of the picture. Unit is meter per pixels so lower is
             better.
         delta (yyyy-mm-dd):
@@ -90,7 +90,7 @@ def rgb_handler(date, polygon, scale, delta):
 @get_param('polygon', parser=Parser.polygon, required=True)
 @get_param('start', parser=int, default=2000)
 @get_param('stop', parser=int, default=2016)
-@get_param('scale', parser=int, default=500)
+@get_param('scale', parser=float, default=500)
 def forest_diff_handler(polygon, start, stop, scale):
     """Generates a RGB image of an are representing {de,re}forestation.
 
@@ -109,7 +109,7 @@ def forest_diff_handler(polygon, start, stop, scale):
         stop (int):
             Year on which we will subtract the data generated from start year.
             Must be greater than start year, and lower than 2016.
-        scale (int):
+        scale (float):
             Precision of the picture. Unit is meter per pixels so lower is
             better.
     Returns:

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -20,6 +20,7 @@ import ee
 import gflags
 import json
 
+from datetime import date
 from dateutil.relativedelta import relativedelta
 from flask import Flask
 from flask import jsonify
@@ -90,7 +91,7 @@ def rgb_handler(date, polygon, scale, delta):
 @app.route('/forestDiff')
 @get_param('polygon', parser=Parser.polygon, required=True)
 @get_param('start', parser=int, default=2000)
-@get_param('stop', parser=int, default=2016)
+@get_param('stop', parser=int, default=date.today().year)
 @get_param('scale', parser=float, default=500)
 def forest_diff_handler(polygon, start, stop, scale):
     """Generates a RGB image of an are representing {de,re}forestation.
@@ -109,7 +110,7 @@ def forest_diff_handler(polygon, start, stop, scale):
             Reference year. Must be greater or equal than 2000.
         stop (int):
             Year on which we will subtract the data generated from start year.
-            Must be greater than start year, and lower than 2016.
+            Must be greater than start year, and lower than current year.
         scale (float):
             Precision of the picture. Unit is meter per pixels so lower is
             better.
@@ -120,9 +121,12 @@ def forest_diff_handler(polygon, start, stop, scale):
             error (str):
                 In case of error, displays the error message.
     """
+    current_year = date.today().year
     try:
-        assert 2000 <= start < 2016, "Start year must be within 2000 and 2016"
-        assert start < stop <= 2016, "Stop year must be within start and 2016"
+        assert 2000 <= start < current_year, ("Start year must be within 2000 "
+            "and %s" % (current_year - 1))
+        assert start < stop <= current_year, ("Stop year must be within start "
+            "and %s" % current_year)
     except AssertionError as e:
         raise Error(str(e))
 

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -20,11 +20,11 @@ import ee
 import gflags
 import json
 
+from dateutil.relativedelta import relativedelta
 from flask import Flask
 from flask import jsonify
 
 from fetcher import ImageFetcher
-from utils import DateDelta
 from utils import Error
 from utils import Parser
 from utils import get_param
@@ -60,7 +60,7 @@ def handle_error(error):
 @get_param("date", parser=Parser.date, required=True)
 @get_param("polygon", parser=Parser.polygon, required=True)
 @get_param("scale", parser=float, default=100)
-@get_param("delta", parser=Parser.date_delta, default=DateDelta(0, 3, 0))
+@get_param("delta", parser=Parser.date_delta, default=relativedelta(months=3))
 def rgb_handler(date, polygon, scale, delta):
     """Generates a RGB image of an area. Images are in PNG (in a zip).
 
@@ -81,7 +81,8 @@ def rgb_handler(date, polygon, scale, delta):
             error (str):
                 In case of error, displays the error message.
     """
-    start_date, end_date = delta.generate_start_end_date(date)
+    start_date = date - delta
+    end_date = date + delta
     url = fetcher.GetRGBImage(start_date, end_date, polygon, scale)
     return jsonify(href=url)
 

--- a/computation/imagefetcher/imagefetcher/app.py
+++ b/computation/imagefetcher/imagefetcher/app.py
@@ -25,9 +25,9 @@ from flask import Flask
 from flask import jsonify
 
 from fetcher import ImageFetcher
-from utils import Error
-from utils import Parser
-from utils import get_param
+from imagefetcher.utils import Error
+from imagefetcher.utils import Parser
+from imagefetcher.utils import get_param
 
 
 app = Flask(__name__)
@@ -134,9 +134,3 @@ def forest_diff_handler(polygon, start, stop, scale):
 def main_route():
     """Simple route useful for checking if the server is alive."""
     return ""
-
-
-if __name__ == "__main__":
-    import sys
-    FLAGS(sys.argv)
-    app.run(host=FLAGS.host, port=FLAGS.port, debug=FLAGS.debug)

--- a/computation/imagefetcher/imagefetcher/app_test.py
+++ b/computation/imagefetcher/imagefetcher/app_test.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 
 import app
+from utils import Parser
 
 FLAGS = gflags.FLAGS
 
@@ -128,6 +129,26 @@ class FlaskApplicationTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200, "Server sent error: %s" %
             response.json().get("error", "[internal error]"))
         self.assertTrue(self.fetcher.GetRGBImage.called)
+
+    def test_rgb_date_delta_supported(self):
+        """Test if date delta is fully supported."""
+        date_parameters = [
+            ("2015-12-01", "0000-1-0"),
+            ("2015-12-31", "0000-0-1"),
+            ("2000-01-01", "0000-3-0"),
+            ("2000-01-01", "0000-0-1"),
+            ("2000-01-01", "0000-1-1"),
+        ]
+
+        for date, delta in date_parameters:
+            response = self.do_request("/rgb", params={
+                'date': date,
+                'polygon': VALID_POLYGON,
+                'delta': delta,
+            })
+            self.assertEqual(response.status_code, 200, "Server sent error: %s" %
+                response.json().get("error", "[internal error]"))
+            self.assertTrue(self.fetcher.GetRGBImage.called)
 
     def test_forest_diff_missing_arguments(self):
         """Test if missing arguments are correctly handled."""

--- a/computation/imagefetcher/imagefetcher/fetcher.py
+++ b/computation/imagefetcher/imagefetcher/fetcher.py
@@ -189,10 +189,10 @@ class ImageFetcher:
 
         Parameters:
             start_year: integer representing the reference year. Must be
-                greater or equal than 2000.
+                greater than or equal to 2000.
             end_year: integer representing the year on which we will subtract
                 the data generated from the start_year. Must be greater than
-                start_year, and lesser or equal to 2016.
+                start_year, and lower than or equal to 2016.
             polygon: area to fetch; a list of latitude and longitude making a
                 polygon.
             scale: image resolution, in meters per pixels.

--- a/computation/imagefetcher/imagefetcher/fetcher.py
+++ b/computation/imagefetcher/imagefetcher/fetcher.py
@@ -192,7 +192,7 @@ class ImageFetcher:
                 greater than or equal to 2000.
             end_year: integer representing the year on which we will subtract
                 the data generated from the start_year. Must be greater than
-                start_year, and lower than or equal to 2016.
+                start_year, and lower than or equal to the current year.
             polygon: area to fetch; a list of latitude and longitude making a
                 polygon.
             scale: image resolution, in meters per pixels.

--- a/computation/imagefetcher/imagefetcher/tests.py
+++ b/computation/imagefetcher/imagefetcher/tests.py
@@ -7,7 +7,7 @@ import threading
 import unittest
 
 import app
-from utils import Parser
+from imagefetcher.utils import Parser
 
 FLAGS = gflags.FLAGS
 

--- a/computation/imagefetcher/imagefetcher/utils.py
+++ b/computation/imagefetcher/imagefetcher/utils.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python2
+
+"""Request handler utilities.
+
+Defines a set of parsers and utilities for easier request handling.
+"""
+
+import functools
+import json
+
+from datetime import datetime
+from flask import request
+
+
+class Error(Exception):
+    """Exception raised when an error occurs in the API."""
+
+    status_code = 400
+
+    def __init__(self, message, status_code=400):
+        Exception.__init__(self)
+        self.message = message
+        self.status_code = status_code
+
+    def to_dict(self):
+        return {"error": self.message}
+
+
+def get_param(param_name, parser=str, required=False, default=None):
+    """Decorator used on route handler to pass a get parameter to the function.
+
+    Parameters:
+        param_name: name of the parameter, used in the request.
+        parser: eventual function parsing the parameter value.
+        required: boolean indicating if the request should be drop if the
+            parameter is missing.
+        default: default value if the parameter is unspecified.
+    Returns:
+        The wrapped function.
+    """
+    if required and default is not None:
+        raise ValueError("A required parameter cannot have a default value.")
+
+    def decorator(func):
+        """Parametrized decorator."""
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            """Wrapper on the function, parsing GET parameter."""
+            param_value = request.args.get(param_name)
+
+            if required and param_value is None:
+                raise Error("Expected GET parameter '%s' missing." %
+                    param_name)
+
+            if param_value is not None:
+                try:
+                    param_value = parser(param_value)
+                except Error:
+                    raise
+                except Exception as e:
+                    raise Error(str(e))
+            else:
+                param_value = default
+
+            kwargs.update({param_name: param_value})
+            return func(*args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+class DateDelta:
+    """Represent a date delta"""
+
+    def __init__(self, year, month, day):
+        """Constructor. Registers the parameters in instance."""
+        self.year = year
+        self.month = month
+        self.day = day
+
+    def generate_start_end_date(self, date):
+        """Generate a start and end date from a datetime object.
+
+        Parameters:
+            date: A date time object, on which we apply the date delta.
+        Returns:
+            A start date (date - delta) and end date (date + delta).
+        """
+        start_date = datetime(date.year - self.year,
+            date.month - self.month, date.day - self.day)
+        end_date = datetime(date.year + self.year,
+            date.month + self.month, date.day + self.day)
+        return start_date, end_date
+
+
+class Parser:
+    """Set of utilities used to parse query parameters."""
+
+    @staticmethod
+    def date(entry):
+        """Parse an entry as a date formated as yyyy-mm-dd.
+
+        Parameters:
+            entry: a string supposed to contain a date.
+        Returns:
+            A datetime object representing a date.
+        Raises:
+            ValueError: if the entry is invalid.
+        """
+        return datetime.strptime(entry, "%Y-%m-%d")
+
+    @staticmethod
+    def polygon(entry):
+        """Parse an entry as a polygon.
+
+        A polygon is a list of coordinates (list of two numbers) representing
+        points of the polygon. The start element and end element must match.
+
+        Examples of valid polygons:
+            [[1, 2], [2, 3], [4, 9], [1, 2]]
+            [[10.9, -23.3, [8, -20], [10, -10], [10.9, -23.3]]]
+
+        Parameters:
+            entry: a string supposed to contain a polygon
+        Returns:
+            A list corresponding to valid polygon
+        Raises:
+            ValueError: if the json is unreadable.
+            AssertionError: if the polygon is invalid.
+        """
+        try:
+            polygon = json.loads(entry)
+        except ValueError:
+            raise ValueError("Unreadable JSON sent.")
+
+        assert type(polygon) == list, "Not a list"
+        assert all(type(p) == list for p in polygon), "Not a list of list."
+        assert all(len(p) == 2 for p in polygon), ("Some points do not have 2 "
+                "coords.")
+        assert all(all(type(c) in (int, float) for c in p)
+                for p in polygon), "Some points have invalid types."
+        assert polygon[0] == polygon[-1], "Last point must equal first point."
+
+        return polygon
+
+    @staticmethod
+    def date_delta(entry):
+        """Parse an entry as a date delta formated as yyyy-mm-dd.
+
+        Parameters:
+            entry: a string supposed to contain a date delta.
+        Returns:
+            A DateDelta object generated from the entry.
+        Raises:
+            ValueError: if the date delta is invalid.
+        """
+        year, month, day = [int(t) for t in entry.split("-")]
+        return DateDelta(year, month, day)

--- a/computation/imagefetcher/imagefetcher/utils.py
+++ b/computation/imagefetcher/imagefetcher/utils.py
@@ -9,6 +9,7 @@ import functools
 import json
 
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from flask import request
 
 
@@ -70,30 +71,6 @@ def get_param(param_name, parser=str, required=False, default=None):
     return decorator
 
 
-class DateDelta:
-    """Represent a date delta"""
-
-    def __init__(self, year, month, day):
-        """Constructor. Registers the parameters in instance."""
-        self.year = year
-        self.month = month
-        self.day = day
-
-    def generate_start_end_date(self, date):
-        """Generate a start and end date from a datetime object.
-
-        Parameters:
-            date: A date time object, on which we apply the date delta.
-        Returns:
-            A start date (date - delta) and end date (date + delta).
-        """
-        start_date = datetime(date.year - self.year,
-            date.month - self.month, date.day - self.day)
-        end_date = datetime(date.year + self.year,
-            date.month + self.month, date.day + self.day)
-        return start_date, end_date
-
-
 class Parser:
     """Set of utilities used to parse query parameters."""
 
@@ -151,9 +128,9 @@ class Parser:
         Parameters:
             entry: a string supposed to contain a date delta.
         Returns:
-            A DateDelta object generated from the entry.
+            A relativedelta object generated from the entry.
         Raises:
             ValueError: if the date delta is invalid.
         """
         year, month, day = [int(t) for t in entry.split("-")]
-        return DateDelta(year, month, day)
+        return relativedelta(years=year, months=month, days=day)

--- a/computation/imagefetcher/requirements.txt
+++ b/computation/imagefetcher/requirements.txt
@@ -4,3 +4,4 @@ earthengine-api
 mock
 flask
 python-gflags
+python-dateutil


### PR DESCRIPTION
Implements a route in the Flask API, /forestDiff, getting the vegetation difference between two years in an area. This will return an RGB image where red stands for deforestation between the two years, green stands for reforestation, and blue is an unapplicable part of the image (such as river, ocean...)